### PR TITLE
feat: Create review 기능 구현   fix : Review 

### DIFF
--- a/src/main/java/com/sparta/legendofdelivery/LegendOfDeliveryApplication.java
+++ b/src/main/java/com/sparta/legendofdelivery/LegendOfDeliveryApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 @EnableJpaAuditing
 public class LegendOfDeliveryApplication {
 

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/controller/OrderController.java
@@ -1,8 +1,11 @@
 package com.sparta.legendofdelivery.domain.order.controller;
 
 import com.sparta.legendofdelivery.domain.order.dto.OrderRequestDto;
+import com.sparta.legendofdelivery.domain.order.entity.Order;
 import com.sparta.legendofdelivery.domain.order.service.OrderService;
+import com.sparta.legendofdelivery.global.dto.DataResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,11 +19,13 @@ public class OrderController {
         this.orderService = orderService;
     }
 
-    @PostMapping("/orders")
-    public ResponseEntity<OrderRequestDto> postOrder(
-            @RequestHeader("Authorization") String token,
-            @Valid @RequestBody OrderRequestDto requestDto) {
+    @PostMapping("/stores/{storeId}/orders/{userId}")
+    public ResponseEntity<DataResponse<Order>> postOrder(@PathVariable Long storeId,
+                                                         @PathVariable Long userId,
+                                                         @Valid @RequestBody OrderRequestDto requestDto) {
 
-        return null;
+        DataResponse<Order> response = orderService.createOrder(storeId, userId, requestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/dto/OrderRequestDto.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OrderRequestDto {
 
-    private Long userId;
-    private Long storeId;
-    private Long count;
+    private Integer count;
+
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/dto/OrderResponseDto.java
@@ -14,13 +14,13 @@ public class OrderResponseDto {
     private LocalDateTime createAt;
     private LocalDateTime modifiedAt;
     private OrderStatusEnum orderStatus; // 주문 접수, 주문 완료
-    private Long count; // 주문 수
+    private Integer count; // 주문 수
     private Long totalPrice; // 가게 * 주문 수
 
     public OrderResponseDto(Order order) {
         this.id = order.getId();
         this.userId = order.getUser().getId();
-//        this.storeId = order.getStore().getId();
+        this.storeId = order.getStore().getId();
         this.createAt = order.getCreateAt();
         this.modifiedAt = order.getModifiedAt();
         this.orderStatus = order.getOrderStatus();

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/entity/Order.java
@@ -1,18 +1,18 @@
 package com.sparta.legendofdelivery.domain.order.entity;
 
 
+import com.sparta.legendofdelivery.domain.order.dto.OrderRequestDto;
 import com.sparta.legendofdelivery.domain.store.entity.Store;
 import com.sparta.legendofdelivery.domain.user.entity.User;
 import com.sparta.legendofdelivery.global.entity.Timestamped;
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "order")
+@Table(name = "orders")
 public class Order extends Timestamped {
 
     @Id
@@ -23,17 +23,23 @@ public class Order extends Timestamped {
     @JoinColumn(name = "user_id")
     private User user;
 
-//    @ManyToOne
-//    @JoinColumn(name = "store_id")
-//    private Store store;
+    @ManyToOne
+    @JoinColumn(name = "store_id")
+    private Store store;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OrderStatusEnum orderStatus;
 
     @Column(nullable = false)
-    private Long count;
+    private Integer count;
 
     @Column(name = "total_price", nullable = false)
     private Long totalPrice;
+
+    public Order(OrderRequestDto requestDto, User user, Store store) {
+        this.count = requestDto.getCount();
+        this.user = user;
+        this.store = store;
+    }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package com.sparta.legendofdelivery.domain.order.repository;
 
 import com.sparta.legendofdelivery.domain.order.dto.OrderResponseDto;
 import com.sparta.legendofdelivery.domain.order.entity.Order;
+import com.sparta.legendofdelivery.domain.store.entity.Store;
 import com.sparta.legendofdelivery.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,4 +10,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository <Order, Long > {
 
+  int countByUserAndStore(User user, Store store);
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/repository/OrderRepository.java
@@ -9,5 +9,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository <Order, Long > {
 
-    Page<OrderResponseDto> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/order/service/OrderService.java
@@ -1,22 +1,41 @@
 package com.sparta.legendofdelivery.domain.order.service;
 
 import com.sparta.legendofdelivery.domain.order.dto.OrderRequestDto;
-import com.sparta.legendofdelivery.domain.order.dto.OrderResponseDto;
+import com.sparta.legendofdelivery.domain.order.entity.Order;
 import com.sparta.legendofdelivery.domain.order.repository.OrderRepository;
-import org.springframework.http.ResponseEntity;
+import com.sparta.legendofdelivery.domain.store.entity.Store;
+import com.sparta.legendofdelivery.domain.store.repository.StoreRepository;
+import com.sparta.legendofdelivery.domain.user.entity.User;
+import com.sparta.legendofdelivery.domain.user.repository.UserRepository;
+import com.sparta.legendofdelivery.global.dto.DataResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
 
-    public OrderService(OrderRepository orderRepository) {
+    public OrderService(OrderRepository orderRepository, UserRepository userRepository, StoreRepository storeRepository) {
         this.orderRepository = orderRepository;
+        this.userRepository = userRepository;
+        this.storeRepository = storeRepository;
     }
 
-    public ResponseEntity<OrderResponseDto> postOrder(OrderRequestDto requestDto) {
-        return null;
-    }
+    public DataResponse<Order> createOrder(Long storeId, Long userId, OrderRequestDto requestDto) {
 
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new IllegalArgumentException("유저를 찾을 수 없습니다.")
+        );
+
+        Store store = storeRepository.findById(storeId).orElseThrow(
+                () -> new IllegalArgumentException("가게를 찾을 수 없습니다")
+        );
+
+        Order order = new Order(requestDto, user, store);
+        Order saveOrder = orderRepository.save(order);
+
+        return new DataResponse<>(200, "주문 생성에 성공했습니다.", saveOrder);
+    }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/controller/ReviewController.java
@@ -1,16 +1,36 @@
 package com.sparta.legendofdelivery.domain.review.controller;
 
 
+import com.sparta.legendofdelivery.domain.review.dto.ReviewRequestDto;
+import com.sparta.legendofdelivery.domain.review.dto.ReviewResponseDto;
 import com.sparta.legendofdelivery.domain.review.service.ReviewService;
+import com.sparta.legendofdelivery.global.dto.DataResponse;
+import com.sparta.legendofdelivery.global.dto.MessageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/review")
+@RequestMapping("/api/reviews")
 @RequiredArgsConstructor
 public class ReviewController {
 
   private final ReviewService reviewService;
 
+  @PostMapping
+  public ResponseEntity<DataResponse<ReviewResponseDto>> createReview(@Valid @RequestBody ReviewRequestDto requestDto
+  // , @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+    ReviewResponseDto responseDto = reviewService.createReview(requestDto /*, userDetails.getUser()*/);
+
+    return ResponseEntity.ok().body(new DataResponse(201, "리뷰 생성에 성공했습니다.", responseDto)
+    );
+  }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/controller/ReviewController.java
@@ -5,13 +5,11 @@ import com.sparta.legendofdelivery.domain.review.dto.ReviewRequestDto;
 import com.sparta.legendofdelivery.domain.review.dto.ReviewResponseDto;
 import com.sparta.legendofdelivery.domain.review.service.ReviewService;
 import com.sparta.legendofdelivery.global.dto.DataResponse;
-import com.sparta.legendofdelivery.global.dto.MessageResponse;
+import com.sparta.legendofdelivery.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,12 +23,13 @@ public class ReviewController {
   private final ReviewService reviewService;
 
   @PostMapping
-  public ResponseEntity<DataResponse<ReviewResponseDto>> createReview(@Valid @RequestBody ReviewRequestDto requestDto
-  // , @AuthenticationPrincipal UserDetailsImpl userDetails
+  public ResponseEntity<DataResponse<ReviewResponseDto>> createReview(
+      @Valid @RequestBody ReviewRequestDto requestDto
+      , @AuthenticationPrincipal UserDetailsImpl userDetails
   ) {
-    ReviewResponseDto responseDto = reviewService.createReview(requestDto /*, userDetails.getUser()*/);
+    ReviewResponseDto responseDto = reviewService.createReview(requestDto , userDetails.getUsername());
 
-    return ResponseEntity.ok().body(new DataResponse(201, "리뷰 생성에 성공했습니다.", responseDto)
+    return ResponseEntity.ok().body(new DataResponse<>(201, "리뷰 생성에 성공했습니다.", responseDto)
     );
   }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewRequestDto.java
@@ -1,12 +1,12 @@
 package com.sparta.legendofdelivery.domain.review.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class ReviewRequestDto {
 
-  @NotBlank
+  @NotNull
   private Long storeId;
   private String comment;
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,12 @@
+package com.sparta.legendofdelivery.domain.review.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ReviewRequestDto {
+
+  @NotBlank
+  private Long storeId;
+  private String comment;
+}

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewResponseDto.java
@@ -16,7 +16,7 @@ public class ReviewResponseDto {
 
   public ReviewResponseDto(Review review) {
     this.id = review.getId();
-//    this.storeId = review.getStoreId();
+    this.storeId = review.getStore().getId();
     this.userId = review.getUser().getId();
     this.content = review.getContent();
     this.createAt = review.getCreateAt();

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,25 @@
+package com.sparta.legendofdelivery.domain.review.dto;
+
+import com.sparta.legendofdelivery.domain.review.entity.Review;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ReviewResponseDto {
+
+  private final Long id;
+  private Long storeId;
+  private final Long userId;
+  private final String content;
+  private final LocalDateTime createAt;
+  private final LocalDateTime modifiedAt;
+
+  public ReviewResponseDto(Review review) {
+    this.id = review.getId();
+//    this.storeId = review.getStoreId();
+    this.userId = review.getUser().getId();
+    this.content = review.getContent();
+    this.createAt = review.getCreateAt();
+    this.modifiedAt = review.getModifiedAt();
+  }
+}

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/entity/Review.java
@@ -1,12 +1,10 @@
 package com.sparta.legendofdelivery.domain.review.entity;
 
-import com.sparta.legendofdelivery.domain.order.entity.Order;
 import com.sparta.legendofdelivery.domain.review.dto.ReviewRequestDto;
 import com.sparta.legendofdelivery.domain.store.entity.Store;
 import com.sparta.legendofdelivery.domain.user.entity.User;
 import com.sparta.legendofdelivery.global.entity.Timestamped;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,7 +13,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -35,12 +32,10 @@ public class Review extends Timestamped {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
-  @Column(nullable = false)
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "store_id")
-  @Column(nullable = false)
   private Store store;
 
 //  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -48,9 +43,9 @@ public class Review extends Timestamped {
 //  private List<Like> likeList = new ArrayList<>();
 
 
-//  public Review(ReviewRequestDto requestDto,Store store, User user) {
-//    this.content = requestDto.getComment();
-//    this.store = store;
-//    this.user = user;
-//  }
+  public Review(ReviewRequestDto requestDto,Store store, User user) {
+    this.content = requestDto.getComment();
+    this.store = store;
+    this.user = user;
+  }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/entity/Review.java
@@ -1,8 +1,12 @@
 package com.sparta.legendofdelivery.domain.review.entity;
 
+import com.sparta.legendofdelivery.domain.order.entity.Order;
+import com.sparta.legendofdelivery.domain.review.dto.ReviewRequestDto;
+import com.sparta.legendofdelivery.domain.store.entity.Store;
 import com.sparta.legendofdelivery.domain.user.entity.User;
 import com.sparta.legendofdelivery.global.entity.Timestamped;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -11,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -25,17 +30,27 @@ public class Review extends Timestamped {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+
   private String content;
 
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "user_id")
-//  private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  @Column(nullable = false)
+  private User user;
 
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "store_id")
-//  private Store store;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_id")
+  @Column(nullable = false)
+  private Store store;
 
 //  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+//  @Column(nullable = false)
 //  private List<Like> likeList = new ArrayList<>();
 
+
+//  public Review(ReviewRequestDto requestDto,Store store, User user) {
+//    this.content = requestDto.getComment();
+//    this.store = store;
+//    this.user = user;
+//  }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,10 @@
 package com.sparta.legendofdelivery.domain.review.repository;
 
 import com.sparta.legendofdelivery.domain.review.entity.Review;
+import com.sparta.legendofdelivery.domain.store.entity.Store;
+import com.sparta.legendofdelivery.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review,Long> {
-
+  int countByUserAndStore(User user, Store store);
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/service/ReviewService.java
@@ -4,10 +4,13 @@ package com.sparta.legendofdelivery.domain.review.service;
 import com.sparta.legendofdelivery.domain.order.repository.OrderRepository;
 import com.sparta.legendofdelivery.domain.review.dto.ReviewRequestDto;
 import com.sparta.legendofdelivery.domain.review.dto.ReviewResponseDto;
+import com.sparta.legendofdelivery.domain.review.entity.Review;
 import com.sparta.legendofdelivery.domain.review.repository.ReviewRepository;
-import com.sparta.legendofdelivery.domain.store.repository.StoreRepository;
+import com.sparta.legendofdelivery.domain.store.entity.Store;
 import com.sparta.legendofdelivery.domain.store.service.StoreService;
 import com.sparta.legendofdelivery.domain.user.entity.User;
+import com.sparta.legendofdelivery.domain.user.service.UserService;
+import com.sparta.legendofdelivery.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,22 +19,26 @@ import org.springframework.stereotype.Service;
 public class ReviewService {
 
   private final ReviewRepository reviewRepository;
-  private final StoreService storeService;
   private final OrderRepository orderRepository;
 
-  public ReviewResponseDto createReview(ReviewRequestDto requestDto
-//      , User user
-  ) {
-// Store store = storeService.findById(requestDto.getStoreId();
-//    int orderCount = orderRepository.countByUserAndStore(user,store);
-//    int reviewCount = reviewRepository.countByUserAndStore(user,store);
-//    if(orderCount <= reviewCount) {
-//    익셉션
-//    }
+  private final StoreService storeService;
+  private final UserService userService;
 
-//  Review review = reviewRepository.save(new Review(requestDto, store, user));
-//    return new ReviewResponseDto(review);
-    return null;
+
+  public ReviewResponseDto createReview(ReviewRequestDto requestDto, String userId) {
+    Store store = storeService.findStoreById(requestDto.getStoreId());
+    User user = userService.findByUserId(userId).orElseThrow(
+        () -> new BadRequestException("존재하지 않는 회원입니다.")
+    );
+
+    int orderCount = orderRepository.countByUserAndStore(user, store);
+    int reviewCount = reviewRepository.countByUserAndStore(user,store);
+    if(orderCount <= reviewCount) {
+    throw new BadRequestException("더 이상 리뷰 작성이 안됩니다.");
+    }
+
+  Review review = reviewRepository.save(new Review(requestDto, store, user));
+    return new ReviewResponseDto(review);
   }
 
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/review/service/ReviewService.java
@@ -1,11 +1,37 @@
 package com.sparta.legendofdelivery.domain.review.service;
 
 
+import com.sparta.legendofdelivery.domain.order.repository.OrderRepository;
+import com.sparta.legendofdelivery.domain.review.dto.ReviewRequestDto;
+import com.sparta.legendofdelivery.domain.review.dto.ReviewResponseDto;
+import com.sparta.legendofdelivery.domain.review.repository.ReviewRepository;
+import com.sparta.legendofdelivery.domain.store.repository.StoreRepository;
+import com.sparta.legendofdelivery.domain.store.service.StoreService;
+import com.sparta.legendofdelivery.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
+
+  private final ReviewRepository reviewRepository;
+  private final StoreService storeService;
+  private final OrderRepository orderRepository;
+
+  public ReviewResponseDto createReview(ReviewRequestDto requestDto
+//      , User user
+  ) {
+// Store store = storeService.findById(requestDto.getStoreId();
+//    int orderCount = orderRepository.countByUserAndStore(user,store);
+//    int reviewCount = reviewRepository.countByUserAndStore(user,store);
+//    if(orderCount <= reviewCount) {
+//    익셉션
+//    }
+
+//  Review review = reviewRepository.save(new Review(requestDto, store, user));
+//    return new ReviewResponseDto(review);
+    return null;
+  }
 
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/controller/StoreController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/stores")
+@RequestMapping("/api/admin/stores")
 public class StoreController {
 
     private final StoreService storeService;
@@ -20,7 +20,7 @@ public class StoreController {
     }
 
     @PostMapping
-    public ResponseEntity<DataResponse> store(@Valid @RequestBody StoreRequestDto requestDto) {
+    public ResponseEntity<DataResponse<Store>> store(@Valid @RequestBody StoreRequestDto requestDto) {
 
         DataResponse<Store> response = storeService.createStore(requestDto);
 
@@ -28,7 +28,7 @@ public class StoreController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<DataResponse> getStores(@PathVariable Long id) {
+    public ResponseEntity<DataResponse<Store>> getStores(@PathVariable Long id) {
 
         DataResponse<Store> response = storeService.getStoreById(id);
 
@@ -37,7 +37,7 @@ public class StoreController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<DataResponse> updateStore(@PathVariable Long id, @Valid @RequestBody StoreRequestDto requestDto) {
+    public ResponseEntity<DataResponse<Store>> updateStore(@PathVariable Long id, @Valid @RequestBody StoreRequestDto requestDto) {
 
         DataResponse<Store> response = storeService.updateStore(id, requestDto);
 

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/controller/StoreController.java
@@ -6,6 +6,7 @@ import com.sparta.legendofdelivery.domain.store.service.StoreService;
 import com.sparta.legendofdelivery.global.dto.DataResponse;
 import com.sparta.legendofdelivery.global.dto.MessageResponse;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,6 +50,27 @@ public class StoreController {
     public ResponseEntity<MessageResponse> deleteStore(@PathVariable Long id) {
 
         return ResponseEntity.ok(storeService.deleteStore(id));
+
+    }
+
+    @GetMapping
+    public Page<Store> getStores(@RequestParam(defaultValue = "0") int page) {
+
+       return storeService.findAllStores(page);
+
+    }
+
+    @PutMapping("/open/{id}")
+    public ResponseEntity<MessageResponse> openStore(@PathVariable Long id) {
+
+        return ResponseEntity.ok(storeService.openStore(id));
+
+    }
+
+    @PutMapping("/close/{id}")
+    public ResponseEntity<MessageResponse> closeStore(@PathVariable Long id) {
+
+        return ResponseEntity.ok(storeService.closeStore(id));
 
     }
 

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/entity/Category.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/entity/Category.java
@@ -1,10 +1,19 @@
 package com.sparta.legendofdelivery.domain.store.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum Category {
 
-    KOREAN,
-    PIZZA,
-    CHINA,
-    BURGER
+    KOREAN(15000),
+    PIZZA(20000),
+    CHINA(12000),
+    BURGER(10000);
+
+    private final int price;
+
+    Category(int price) {
+        this.price = price;
+    }
 
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/entity/Store.java
@@ -1,6 +1,7 @@
 package com.sparta.legendofdelivery.domain.store.entity;
 
 import com.sparta.legendofdelivery.domain.store.dto.StoreRequestDto;
+import com.sparta.legendofdelivery.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Store {
+public class Store extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,11 +38,22 @@ public class Store {
         this.name = requestDto.getName();
         this.category = requestDto.getCategory();
         this.intro = requestDto.getIntro();
+        this.dibsCount = 0L;
+        this.reviewCount = 0L;
+        this.storeState = StoreState.CLOSE;
     }
 
     public void updateStore (StoreRequestDto requestDto) {
         this.name = requestDto.getName();
         this.category = requestDto.getCategory();
         this.intro = requestDto.getIntro();
+    }
+
+    public void openStore () {
+        this.storeState = StoreState.OPEN;
+    }
+
+    public void closeStore () {
+        this.storeState = StoreState.CLOSE;
     }
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/entity/Store.java
@@ -56,4 +56,5 @@ public class Store extends Timestamped {
     public void closeStore () {
         this.storeState = StoreState.CLOSE;
     }
+
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/repository/StoreRepository.java
@@ -1,9 +1,12 @@
 package com.sparta.legendofdelivery.domain.store.repository;
 
 import com.sparta.legendofdelivery.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface  StoreRepository extends JpaRepository<Store, Long> {
+    Page<Store> findAllByOrderByCreateAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/service/StoreService.java
@@ -6,6 +6,9 @@ import com.sparta.legendofdelivery.domain.store.repository.StoreRepository;
 import com.sparta.legendofdelivery.global.dto.DataResponse;
 import com.sparta.legendofdelivery.global.dto.MessageResponse;
 import com.sparta.legendofdelivery.global.exception.BadRequestException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,7 +52,44 @@ public class StoreService {
         findStoreById(id);
         storeRepository.deleteById(id);
 
-        return new MessageResponse(200, "가게 삭제에 성공 하셧습니다");
+        return new MessageResponse(200, "가게 삭제에 성공 하셨습니다");
+
+    }
+
+    public Page<Store> findAllStores(int page) {
+
+        Pageable pageable = PageRequest.of(page, 5);
+        Page<Store> storePage = storeRepository.findAll(pageable);
+
+        if (!storePage.hasContent()) {
+            throw new BadRequestException("가게 데이터가 비어있습니다.");
+        }
+
+        if (page >= storePage.getTotalPages()) {
+            throw new BadRequestException("토탈 페이지를 넘기는 요청은 안됩니다.");
+        }
+
+        return storeRepository.findAllByOrderByCreateAtDesc(pageable);
+
+    }
+
+    @Transactional
+    public MessageResponse openStore(Long id) {
+
+        Store store = findStoreById(id);
+        store.openStore();
+
+        return new MessageResponse(200, store.getName() + " 이(가) 오픈 되었습니다.");
+
+    }
+
+    @Transactional
+    public MessageResponse closeStore(Long id) {
+
+        Store store = findStoreById(id);
+        store.closeStore();
+
+        return new MessageResponse(200, store.getName() + " 이(가) 마감 되었습니다.");
 
     }
 

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/service/StoreService.java
@@ -104,7 +104,7 @@ public class StoreService {
 
     }
 
-    private Store findStoreById(Long id) {
+    public Store findStoreById(Long id) {
         return storeRepository.findById(id)
                 .orElseThrow(() -> new BadRequestException("해당 가게는 존재하지 않습니다."));
     }

--- a/src/main/java/com/sparta/legendofdelivery/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/store/service/StoreService.java
@@ -2,6 +2,7 @@ package com.sparta.legendofdelivery.domain.store.service;
 
 import com.sparta.legendofdelivery.domain.store.dto.StoreRequestDto;
 import com.sparta.legendofdelivery.domain.store.entity.Store;
+import com.sparta.legendofdelivery.domain.store.entity.StoreState;
 import com.sparta.legendofdelivery.domain.store.repository.StoreRepository;
 import com.sparta.legendofdelivery.global.dto.DataResponse;
 import com.sparta.legendofdelivery.global.dto.MessageResponse;
@@ -77,6 +78,11 @@ public class StoreService {
     public MessageResponse openStore(Long id) {
 
         Store store = findStoreById(id);
+
+        if(store.getStoreState().equals(StoreState.OPEN)){
+            throw new BadRequestException("이미 오픈된 가게 입니다.");
+        }
+
         store.openStore();
 
         return new MessageResponse(200, store.getName() + " 이(가) 오픈 되었습니다.");
@@ -87,6 +93,11 @@ public class StoreService {
     public MessageResponse closeStore(Long id) {
 
         Store store = findStoreById(id);
+
+        if(store.getStoreState().equals(StoreState.CLOSE)){
+            throw new BadRequestException("이미 마감된 가게 입니다.");
+        }
+
         store.closeStore();
 
         return new MessageResponse(200, store.getName() + " 이(가) 마감 되었습니다.");

--- a/src/main/java/com/sparta/legendofdelivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.sparta.legendofdelivery.domain.user.controller;
 
-import com.sparta.legendofdelivery.domain.user.dto.UserLoginRequestDto;
 import com.sparta.legendofdelivery.domain.user.dto.UserSignupRequestDto;
 import com.sparta.legendofdelivery.domain.user.service.UserService;
 import com.sparta.legendofdelivery.global.dto.MessageResponse;
@@ -28,14 +27,6 @@ public class UserController {
         userService.signup(requestDto);
 
         return createResponseEntity(HttpStatus.CREATED, "회원가입에 성공했습니다.");
-    }
-
-    @PostMapping("/login")
-    public ResponseEntity<MessageResponse> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
-
-        userService.login(requestDto);
-
-        return createResponseEntity(HttpStatus.OK, "로그인에 성공했습니다.");
     }
 
     private ResponseEntity<MessageResponse> createResponseEntity(HttpStatus httpStatusCode, String message) {

--- a/src/main/java/com/sparta/legendofdelivery/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/user/entity/User.java
@@ -56,4 +56,8 @@ public class User extends Timestamped {
         this.password = encryptionPassword;
     }
 
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/user/entity/UserRole.java
@@ -1,8 +1,17 @@
 package com.sparta.legendofdelivery.domain.user.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum UserRole {
 
-    USER,
-    ADMIN;
+    USER("USER"),
+    ADMIN("ADMIN");
+
+    private final String role;
+
+    UserRole(String role) {
+        this.role = role;
+    }
 
 }

--- a/src/main/java/com/sparta/legendofdelivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/legendofdelivery/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.sparta.legendofdelivery.domain.user.service;
 
-import com.sparta.legendofdelivery.domain.user.dto.UserLoginRequestDto;
 import com.sparta.legendofdelivery.domain.user.dto.UserSignupRequestDto;
 import com.sparta.legendofdelivery.domain.user.entity.User;
 import com.sparta.legendofdelivery.domain.user.entity.UserOauth;
@@ -41,22 +40,8 @@ public class UserService {
 
     }
 
-    public void login(UserLoginRequestDto requestDto) {
-
-        Optional<User> user = findByUserId(requestDto.getUserId());
-
-        if (user.isEmpty() || user.get().getStatus().equals(UserStatus.LEAVE) || !checkPassword(requestDto.getPassword(), user.get().getPassword())) {
-            throw new BadRequestException("아이디, 비밀번호를 확인해주세요.");
-        }
-
-    }
-
     public Optional<User> findByUserId(String userId) {
         return userRepository.findByUserId(userId);
-    }
-
-    private boolean checkPassword(String requestPassword, String userPassword) {
-        return passwordEncoder.matches(requestPassword, userPassword);
     }
 
 }

--- a/src/main/java/com/sparta/legendofdelivery/global/jwt/JwtProvider.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/jwt/JwtProvider.java
@@ -40,7 +40,7 @@ public class JwtProvider {
 
     }
 
-    private String generateToken(String userId, UserRole role, Date expirationDate) {
+    private String generateToken(String userId, String role, Date expirationDate) {
         return Jwts.builder()
                 .setSubject(userId)
                 .claim("auth", role)
@@ -57,14 +57,14 @@ public class JwtProvider {
         return new Date(date.getTime() + ms);
     }
 
-    public String createAccessToken(String userId, UserRole role) {
+    public String createAccessToken(String userId, String role) {
 
         Date expirationDate = generateExpirationDate(ACCESS_TOKEN_EXPIRATION);
 
         return generateToken(userId, role, expirationDate);
     }
 
-    public String createRefreshToken(String userId, UserRole role) {
+    public String createRefreshToken(String userId, String role) {
 
         Date expirationDate = generateExpirationDate(REFRESH_TOKEN_EXPIRATION);
 

--- a/src/main/java/com/sparta/legendofdelivery/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.sparta.legendofdelivery.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("text/plain;charset=UTF-8");
+        response.getWriter().write("로그인 후 이용해 주세요.");
+    }
+
+}

--- a/src/main/java/com/sparta/legendofdelivery/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,95 @@
+package com.sparta.legendofdelivery.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.legendofdelivery.domain.user.dto.UserLoginRequestDto;
+import com.sparta.legendofdelivery.domain.user.entity.User;
+import com.sparta.legendofdelivery.domain.user.entity.UserStatus;
+import com.sparta.legendofdelivery.domain.user.repository.UserRepository;
+import com.sparta.legendofdelivery.global.dto.MessageResponse;
+import com.sparta.legendofdelivery.global.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, UserRepository userRepository) {
+        this.jwtProvider = jwtProvider;
+        this.userRepository = userRepository;
+        setFilterProcessesUrl("/api/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        if (!request.getMethod().equals("POST")) {
+            throw new AuthenticationServiceException("잘못된 http 요청입니다.");
+        }
+
+        try {
+
+            UserLoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), UserLoginRequestDto.class);
+
+            return getAuthenticationManager().authenticate(new UsernamePasswordAuthenticationToken(requestDto.getUserId(), requestDto.getPassword(), null));
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
+
+        UserDetailsImpl userDetails = (UserDetailsImpl) authResult.getPrincipal();
+        String userId = userDetails.getUsername();
+        String role = userDetails.getAuthorities().iterator().next().getAuthority();
+
+        Optional<User> user = userRepository.findByUserId(userId);
+
+        if (user.isEmpty() || user.get().getStatus().equals(UserStatus.LEAVE)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.setContentType("application/json;charset=UTF-8");
+            MessageResponse messageResponse = new MessageResponse(400, "아이디, 비밀번호를 확인해주세요.");
+            String json = new ObjectMapper().writeValueAsString(messageResponse);
+            response.getWriter().write(json);
+        }
+
+        String accessToken = jwtProvider.createAccessToken(userId, role);
+        String refreshToken = jwtProvider.createRefreshToken(userId, role);
+        ResponseCookie refreshTokenCookie = jwtProvider.createCookieRefreshToken(refreshToken);
+
+        user.get().updateRefreshToken(refreshToken);
+
+        response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+        MessageResponse messageResponse = new MessageResponse(200, "로그인에 성공했습니다.");
+        String json = new ObjectMapper().writeValueAsString(messageResponse);
+        response.getWriter().write(json);
+
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json;charset=UTF-8");
+        MessageResponse messageResponse = new MessageResponse(400, "아이디, 비밀번호를 확인해주세요.");
+        String json = new ObjectMapper().writeValueAsString(messageResponse);
+        response.getWriter().write(json);
+    }
+
+}

--- a/src/main/java/com/sparta/legendofdelivery/global/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/security/JwtAuthorizationFilter.java
@@ -1,0 +1,73 @@
+package com.sparta.legendofdelivery.global.security;
+
+import com.sparta.legendofdelivery.global.jwt.JwtProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthorizationFilter(JwtProvider jwtProvider, UserDetailsServiceImpl userDetailsService) {
+        this.jwtProvider = jwtProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtProvider.getAccessTokenFromHeader(request);
+
+        if (StringUtils.hasText(tokenValue)) {
+
+            try {
+
+                Claims info = jwtProvider.getClaimsFromToken(tokenValue);
+                setAuthentication(info.getSubject());
+
+            } catch (ExpiredJwtException e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("text/plain;charset=UTF-8");
+                response.getWriter().write("만료된 토큰 입니다.");
+            } catch (JwtException e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("text/plain;charset=UTF-8");
+                response.getWriter().write("유효하지 않은 토큰 입니다.");
+            }
+
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    public void setAuthentication(String userId) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(userId);
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+
+    private Authentication createAuthentication(String userId) {
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+}

--- a/src/main/java/com/sparta/legendofdelivery/global/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/security/SecurityConfig.java
@@ -1,0 +1,72 @@
+package com.sparta.legendofdelivery.global.security;
+
+import com.sparta.legendofdelivery.domain.user.repository.UserRepository;
+import com.sparta.legendofdelivery.global.jwt.JwtProvider;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final UserRepository userRepository;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    public SecurityConfig(JwtProvider jwtProvider, UserDetailsServiceImpl userDetailsService, AuthenticationConfiguration authenticationConfiguration, UserRepository userRepository, CustomAuthenticationEntryPoint customAuthenticationEntryPoint) {
+        this.jwtProvider = jwtProvider;
+        this.userDetailsService = userDetailsService;
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.userRepository = userRepository;
+        this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtProvider, userRepository);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtProvider, userDetailsService);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.csrf( (csrf) -> csrf.disable());
+
+        http.sessionManagement( (sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests( (authorizeHttpRequests) -> authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("**").permitAll()
+                        .anyRequest().authenticated())
+                .exceptionHandling( (exceptionHandling) -> {
+                    exceptionHandling.authenticationEntryPoint(customAuthenticationEntryPoint);
+                })
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/sparta/legendofdelivery/global/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/security/UserDetailsImpl.java
@@ -1,0 +1,63 @@
+package com.sparta.legendofdelivery.global.security;
+
+import com.sparta.legendofdelivery.domain.user.entity.User;
+import com.sparta.legendofdelivery.domain.user.entity.UserRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        UserRole role = user.getRole();
+        String roleString = role.getRole();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(roleString);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/sparta/legendofdelivery/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/legendofdelivery/global/security/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.sparta.legendofdelivery.global.security;
+
+import com.sparta.legendofdelivery.domain.user.entity.User;
+import com.sparta.legendofdelivery.domain.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+
+        User user = userRepository.findByUserId(userId).orElseThrow( () -> new UsernameNotFoundException("아이디, 비밀번호를 확인해주세요."));
+
+        return new UserDetailsImpl(user);
+    }
+
+}


### PR DESCRIPTION
JPA에서 @ManyToOne 와 @JoinColumn 어노테이션을 사용하여 엔티티 간의 관계를 정의 하는데

@Column 어노테이션은 기본 필드와 함께 사용되며 관계를 나타내는 필드와 함께 사용 하니  에러가 떠서 제거

Vaild에서 @NotBlank 어노테이션은 기본적으로 문자열(String) 필드에 대해서만 사용 -> Long 타입 @NotNull 로 변경

StoreService에 findStoreById 매서드 재사용하기위해 public 으로 변경

OrderRepository에 countByUserAndStore 매서드 생성